### PR TITLE
ALPHA-3934

### DIFF
--- a/Emif.Adapter.Schema.csproj
+++ b/Emif.Adapter.Schema.csproj
@@ -13,9 +13,17 @@
     <AssemblyName>Emif.Adapter.Schema</AssemblyName>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NoWarn>CS8981</NoWarn> <!-- needed because of code generation from protoc-->
+    <NoWarn>CS1591</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.24.4" />
-    <PackageReference Include="Google.Protobuf.Tools" Version="3.24.4" />
+    <PackageReference Include="Grpc.Tools" Version="2.59.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update toolchain to use Grpc.Tools instead of Google.Protobuf.Tools version.